### PR TITLE
Add timestamp/feature

### DIFF
--- a/flask_logging_server/logserver.py
+++ b/flask_logging_server/logserver.py
@@ -1,9 +1,9 @@
 import logging
 from logging.handlers import TimedRotatingFileHandler
-from flask import Flask, jsonify, render_template, send_from_directory
+from flask import Flask, jsonify, render_template, send_from_directory, request
 import os
 import json
-
+from datetime import datetime
 
 # Set paths for log files
 log_directory = '/app/logs/'
@@ -42,6 +42,11 @@ pynetdicom_logger.addHandler(logging.FileHandler(log_file_path))
 
 app = Flask(__name__)
 
+def get_server_status():
+    return {
+        "status": "running",
+        "last_updated": datetime.now().isoformat()
+    }
 @app.route('/')
 def landing_page():
   
@@ -49,7 +54,14 @@ def landing_page():
 
 @app.route('/home')
 def home():
-    return render_template('status.html')
+    try:
+        server_status = get_server_status()
+        return render_template('home.html', 
+                         status=server_status["status"],
+                         last_updated=server_status["last_updated"])
+    except Exception as e:
+        exception_logger.error(f"Error in home route: {e}")
+        return jsonify({"error": str(e)}), 500
 
 @app.route('/logs')
 def logs():
@@ -57,7 +69,16 @@ def logs():
 
 @app.route('/status')
 def status():
-    return jsonify({"status": "running"})
+    try:
+        server_status = get_server_status()
+        if request.headers.get('Accept') == 'application/json':
+            return jsonify(server_status)
+        return render_template('status.html', 
+                             status=server_status["status"],
+                             last_updated=server_status["last_updated"])
+    except Exception as e:
+        exception_logger.error(f"Error in status route: {e}")
+        return jsonify({"error": str(e)}), 500
 
 @app.route('/logs/all')
 def all_logs():

--- a/flask_logging_server/logserver.py
+++ b/flask_logging_server/logserver.py
@@ -43,10 +43,18 @@ pynetdicom_logger.addHandler(logging.FileHandler(log_file_path))
 app = Flask(__name__)
 
 def get_server_status():
-    return {
-        "status": "running",
-        "last_updated": datetime.now().isoformat()
-    }
+    try:
+        return {
+            "status": "running",
+            "last_updated": datetime.now().isoformat()
+        }
+    except Exception as e:
+        exception_logger.error(f"Error getting server status: {e}")
+        return {
+            "status": "error",
+            "last_updated": None,
+            "error": str(e)
+        }
 @app.route('/')
 def landing_page():
   

--- a/flask_logging_server/static/styles.css
+++ b/flask_logging_server/static/styles.css
@@ -128,3 +128,24 @@ footer {
         font-size: 1.2em;
     }
 }
+
+.status-container {
+    padding: 20px;
+    background-color: white;
+    margin: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+#status-timestamp {
+    color: #666;
+    font-size: 0.9em;
+    margin-top: 10px;
+    font-family: monospace;
+}
+
+#status-display {
+    padding: 15px;
+    background-color: #f9f9f9;
+    border-radius: 4px;
+}

--- a/flask_logging_server/templates/base.html
+++ b/flask_logging_server/templates/base.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>DICOMHawk</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    {% block styles %}{% endblock %}
+</head>
+<body>
+    <div class="container">
+        {% block content %}{% endblock %}
+    </div>
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/flask_logging_server/templates/home.html
+++ b/flask_logging_server/templates/home.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>DICOMHawk Home</title>
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+    <h1>DICOMHawk Dashboard</h1>
+    <div id="status-container" class="status-container">
+        <div id="status-display">
+            <p>Status: <span id="server-status">{{ status }}</span></p>
+            <p id="status-timestamp">Last Updated: {{ last_updated }}</p>
+        </div>
+    </div>
+    <script src="{{ url_for('static', filename='scripts.js') }}"></script>
+</body>
+</html>

--- a/flask_logging_server/templates/status.html
+++ b/flask_logging_server/templates/status.html
@@ -6,8 +6,11 @@
 </head>
 <body>
     <h1>DICOM Server Status</h1>
-    <div id="status-container">
-        <p id="status">Loading...</p>
+    <div id="status-container" class="status-container">
+        <div id="status-display">
+            <p>Status: <span id="server-status">{{ status }}</span></p>
+            <p id="status-timestamp">Last Updated: {{ last_updated }}</p>
+        </div>
     </div>
     <script src="{{ url_for('static', filename='scripts.js') }}"></script>
 </body>


### PR DESCRIPTION
# Add Timestamp Feature to Server Status Display

## Changes
- Added timestamp functionality to server status with ISO format
- Created separate home and status pages with unique layouts
- Added auto-refresh every 30 seconds for real-time updates
- Updated CSS styling for better timestamp display
- Created base template for consistent page structure
- Improved error handling for status endpoints

## Testing
- Verified timestamp updates on both /status and /home
- Tested JSON API endpoint with proper headers
- Checked auto-refresh functionality
- Verified error handling and logging
- Tested Docker container deployment

## Features
The status page now shows:
- Current server status
- Last updated timestamp
- Auto-refreshing display
- Consistent styling across pages

## Screenshots
*Home Page*
![Screenshot 2025-02-07 025547](https://github.com/user-attachments/assets/d8bf703c-ac2f-4cde-9373-35f842fa4664)


*Server Status Page*
![Screenshot 2025-02-07 025603](https://github.com/user-attachments/assets/0f6419f2-5630-4cec-aa02-415905a4d862)



Closes #2

/cc @gtheodoridis